### PR TITLE
Extract users to separate model. Allow to pass user id type so it can…

### DIFF
--- a/src/BioEngine.Extra.Ads.Api/AdsController.cs
+++ b/src/BioEngine.Extra.Ads.Api/AdsController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using BioEngine.Core.Api;
-using BioEngine.Core.DB;
 using BioEngine.Core.Entities;
 using BioEngine.Core.Repository;
 using BioEngine.Core.Web;
@@ -16,8 +15,8 @@ namespace BioEngine.Extra.Ads.Api
         AdsApiController : ContentEntityController<Ad, AdsRepository, Entities.Ad, Entities.Ad>
     {
         protected AdsApiController(BaseControllerContext<Ad, AdsRepository> context,
-            BioEntitiesManager entitiesManager, ContentBlocksRepository blocksRepository) : base(context,
-            entitiesManager, blocksRepository)
+            ContentBlocksRepository blocksRepository) : base(context,
+            blocksRepository)
         {
         }
 

--- a/src/BioEngine.Extra.Ads/AdsModule.cs
+++ b/src/BioEngine.Extra.Ads/AdsModule.cs
@@ -1,16 +1,28 @@
 using BioEngine.Core.DB;
 using BioEngine.Core.Modules;
 using BioEngine.Extra.Ads.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace BioEngine.Extra.Ads
 {
     public abstract class AdsModule : BaseBioEngineModule
     {
-        public override void ConfigureEntities(IServiceCollection serviceCollection, BioEntitiesManager entitiesManager)
+        public override void ConfigureDbContext(IServiceCollection services, IConfiguration configuration, IHostEnvironment environment)
         {
-            base.ConfigureEntities(serviceCollection, entitiesManager);
-            RegisterRepositories(typeof(Ad).Assembly, serviceCollection, entitiesManager);
+            base.ConfigureDbContext(services, configuration, environment);
+            RegisterEntities<AdsModule>(services);
+        }
+    }
+
+    public class AdsBioContextModelConfigurator : IBioContextModelConfigurator
+    {
+        public void Configure(ModelBuilder modelBuilder, ILogger<BioContext> logger)
+        {
+            modelBuilder.RegisterSiteEntity<Ad>();
         }
     }
 }


### PR DESCRIPTION
… be defined on application level, not hardcoded as string. Separate content items. Don't use single table for them.